### PR TITLE
Fixed typo for GitHub link in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ extra:
     - icon: fontawesome/brands/font-awesome
       link: https://cake-dri.github.io/
     - icon: fontawesome/brands/github
-      link: https://github.com/CAKE_DRI
+      link: https://github.com/CAKE-DRI
     - icon: fontawesome/brands/slack
       link: https://join.slack.com/t/cake-dri/shared_invite/zt-3b6dgtkfp-kDnlCOXOl9QJrg0L7tVKNw
 


### PR DESCRIPTION
The link at the bottom of the pages linked to CAKE_DRI not CAKE-DRI, giving a 404 error when clicking