### PR TITLE
Updates wording and facilitation -> tools

### DIFF
--- a/docs/collaboration-and-community-building/oops-did-we-do-it-right.md
+++ b/docs/collaboration-and-community-building/oops-did-we-do-it-right.md
@@ -1,6 +1,6 @@
 ---
 title: Oops did we do it right? Lessons from Successful Collaborations 
-tags: [Collaboration & Community Building]
+# tags: [Collaboration & Community Building]
 ---
 
 ## Session summary: 

--- a/docs/community-tips/collaboration.md
+++ b/docs/community-tips/collaboration.md
@@ -1,13 +1,12 @@
 ---
 title: Collaboration
-tags: [Top Tips, Collaboration]
+tags: [Sprinkles of Knowledge, Collaboration]
 ---
 
 # 🤝 Collaboration
+This theme is about **working better together**. What helps collaboration feel easier, healthier, or more effective?
 
-This page is part of our Top Tips campaign — a space to share quick advice, useful experiences, and things you wish someone had told you earlier.
-
-This topic is **Collaboration & Working Together**. How do we make collaboration easier, healthier, and more effective?
+Add your sprinkles of knowledge below: a quick tip, small insight, or lesson learned.
 
 <div class="sticky-board">
 
@@ -32,7 +31,7 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
 
 ---
 
-## ✨ Share your experience
+## Add your sticky note
 
 <div class="submit-box">
 
@@ -41,6 +40,7 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
   </p>
   
   <p class="submit-helper">
+  </br>
   After clicking <strong>Submit</strong>, a GitHub issue will open
   with your tip pre-filled. Simply click <strong>Create issue</strong>
   to send it to the CAKE team for review before it goes live.
@@ -49,13 +49,13 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
   <input
     class="tip-input"
     id="tip-title"
-    placeholder="Tip title"
+    placeholder="Title"
   />
 
   <textarea
     class="tip-textarea"
     id="tip-text"
-    placeholder="Your advice..."
+    placeholder="Your text..."
   ></textarea>
 
   <div class="tip-controls">
@@ -63,7 +63,7 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
 
 <div class="emoji-picker">
   <p class="emoji-label">
-    Select an emoji!
+    Select an emoji:
   </p>
 
   <div class="emoji-grid" id="tip-emoji">
@@ -92,7 +92,7 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
 <div class="colour-picker">
 
   <p class="emoji-label">
-    Select your sticky note colour!
+    Select your colour:
   </p>
 
   <div class="colour-grid" id="tip-colour">
@@ -143,8 +143,13 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
 
 </div>
 
+---
 
-!!! question "Contributing:" 
+## Explore our other themes
+
+<!-- material/tags {include: [Sprinkles of Knowledge]} -->
+
+<!-- !!! question "Contributing:" 
 
 
     Read our [How to contribute](../how-to-contribute/index.md) guide for more.
@@ -155,7 +160,7 @@ This topic is **Collaboration & Working Together**. How do we make collaboration
     * Be respectful of different viewpoints and experiences
     * Gracefully accept constructive criticism
     * Focus on what is best for the community
-    * Show courtesy and respect towards others
+    * Show courtesy and respect towards others -->
 
 
 <script>

--- a/docs/community-tips/events.md
+++ b/docs/community-tips/events.md
@@ -1,13 +1,12 @@
 ---
 title: Events
-tags: [Top Tips, Events]
+tags: [Sprinkles of Knowledge, Events]
 ---
 
 # 🤝 Events
+This theme is about **preparing for conferences, events, talks**. Whether you’re preparing to attend, organising, or speaking, share anything that helped (or would have helped) you.
 
-This page is part of our Top Tips campaign — a space to share quick advice, useful experiences, and things you wish someone had told you earlier.
-
-This topic is **Preparing for Conferences, Events, Talks**. Whether you’re preparing to attend, organising, or speaking, share anything that helped (or would have helped) you.
+Add your sprinkles of knowledge below: a quick tip, small insight, or lesson learned.
 
 <div class="sticky-board">
 
@@ -29,7 +28,7 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
 
 ---
 
-## ✨ Share your experience
+## Add your sticky note
 
 <div class="submit-box">
 
@@ -38,6 +37,7 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
   </p>
   
   <p class="submit-helper">
+  </br>
   After clicking <strong>Submit</strong>, a GitHub issue will open
   with your tip pre-filled. Simply click <strong>Create issue</strong>
   to send it to the CAKE team for review before it goes live.
@@ -46,13 +46,13 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
   <input
     class="tip-input"
     id="tip-title"
-    placeholder="Tip title"
+    placeholder="Title"
   />
 
   <textarea
     class="tip-textarea"
     id="tip-text"
-    placeholder="Your advice..."
+    placeholder="Your text..."
   ></textarea>
 
   <div class="tip-controls">
@@ -60,7 +60,7 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
 
 <div class="emoji-picker">
   <p class="emoji-label">
-    Select an emoji!
+    Select an emoji:
   </p>
 
   <div class="emoji-grid" id="tip-emoji">
@@ -89,7 +89,7 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
 <div class="colour-picker">
 
   <p class="emoji-label">
-    Select your sticky note colour!
+    Select your colour:
   </p>
 
   <div class="colour-grid" id="tip-colour">
@@ -141,7 +141,13 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
 </div>
 
 
-!!! question "Contributing:" 
+---
+
+## Explore our other themes
+
+<!-- material/tags {include: [Sprinkles of Knowledge]} -->
+
+<!-- !!! question "Contributing:" 
 
 
     Read our [How to contribute](../how-to-contribute/index.md) guide for more.
@@ -152,7 +158,7 @@ This topic is **Preparing for Conferences, Events, Talks**. Whether you’re pre
     * Be respectful of different viewpoints and experiences
     * Gracefully accept constructive criticism
     * Focus on what is best for the community
-    * Show courtesy and respect towards others
+    * Show courtesy and respect towards others -->
 
     
 

--- a/docs/community-tips/inclusion.md
+++ b/docs/community-tips/inclusion.md
@@ -1,13 +1,13 @@
 ---
-title: Inclusive Practice & Community Care
-tags: [Top Tips, Inclusion]
+title: Inclusion
+tags: [Sprinkles of Knowledge, Inclusion]
 ---
 
 # 🤝 Inclusion
 
-This page is part of our Top Tips campaign — a space to share quick advice, useful experiences, and things you wish someone had told you earlier.
+This theme is about **inclusive practice & community care**. Small things that help people feel included, supported, and able to participate.
 
-This topic is **Inclusive Practice & Community Care**. Small things that help people feel included, supported, and able to participate.
+Add your sprinkles of knowledge below: a quick tip, small insight, or lesson learned.
 
 <div class="sticky-board">
 
@@ -29,7 +29,7 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
 
 ---
 
-## ✨ Share your experience
+## Add your sticky note
 
 <div class="submit-box">
 
@@ -38,6 +38,7 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
   </p>
   
   <p class="submit-helper">
+  </br>
   After clicking <strong>Submit</strong>, a GitHub issue will open
   with your tip pre-filled. Simply click <strong>Create issue</strong>
   to send it to the CAKE team for review before it goes live.
@@ -46,13 +47,13 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
   <input
     class="tip-input"
     id="tip-title"
-    placeholder="Tip title"
+    placeholder="Title"
   />
 
   <textarea
     class="tip-textarea"
     id="tip-text"
-    placeholder="Your advice..."
+    placeholder="Your text..."
   ></textarea>
 
   <div class="tip-controls">
@@ -60,7 +61,7 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
 
 <div class="emoji-picker">
   <p class="emoji-label">
-    Select an emoji!
+    Select an emoji:
   </p>
 
   <div class="emoji-grid" id="tip-emoji">
@@ -89,7 +90,7 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
 <div class="colour-picker">
 
   <p class="emoji-label">
-    Select your sticky note colour!
+    Select your colour:
   </p>
 
   <div class="colour-grid" id="tip-colour">
@@ -140,7 +141,13 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
 
 </div>
 
-!!! question "Contributing:" 
+---
+
+## Explore our other themes
+
+<!-- material/tags {include: [Sprinkles of Knowledge]} -->
+
+<!-- !!! question "Contributing:" 
 
 
     Read our [How to contribute](../how-to-contribute/index.md) guide for more.
@@ -151,7 +158,7 @@ This topic is **Inclusive Practice & Community Care**. Small things that help pe
     * Be respectful of different viewpoints and experiences
     * Gracefully accept constructive criticism
     * Focus on what is best for the community
-    * Show courtesy and respect towards others
+    * Show courtesy and respect towards others -->
 
 <script>
 

--- a/docs/community-tips/index.md
+++ b/docs/community-tips/index.md
@@ -1,21 +1,13 @@
 ---
-title: Community Top Tips
-tags: [Central themes, Top Tips]
+title: Sprinkles of Knowledge
+tags: [Central themes, Sprinkles of Knowledge]
 ---
 
-A space to share quick advice, useful experiences, and things you wish someone had told you earlier.
+Welcome to **Sprinkles of Knowledge!** This is where you can find quick tips, advice, and experiences from our community.
 
-## Why this exists
+The most helpful ideas are often simple: a practical tip, something that worked, a mistake to avoid, or a small insight from experience.
 
-Often the most helpful things are simple — a practical tip, something that worked, a mistake to avoid, or a small insight from experience.
-
-**Community Top Tips is designed to make sharing those things easy.** Whether it’s about events, collaboration, communication, or inclusive practice, this is a lightweight space for sharing what you’ve learned.
-
-Curated by the [CAKE team](https://www.cake.ac.uk/about/who-are-we).
-
-## Explore Themes
-
-Browse community advice by topic.
+Browse our sprinkles by the themes below or share your own. *Curated by the [CAKE team](https://www.cake.ac.uk/about/who-are-we).*
 
 <div class="tip-theme-grid">
 
@@ -23,7 +15,7 @@ Browse community advice by topic.
   {"name": "Events", "tag": "events", "icon": "🎤", "desc": "Workshops, conferences and hybrid meetings."},
   {"name": "Collaboration", "tag": "collaboration", "icon": "🤝", "desc": "Working together across teams and disciplines."},
   {"name": "Inclusion", "tag": "inclusion", "icon": "🌍", "desc": "Accessibility and inclusive community practices."},
-  {"name": "Facilitation", "tag": "facilitation", "icon": "🧠", "desc": "Helping groups work better together."}
+  {"name": "Tools & Workflows", "tag": "tools", "icon": "🧠", "desc": "The right tools for the right job."}
 ] %}
 
 {% for theme in themes %}
@@ -43,25 +35,233 @@ Browse community advice by topic.
 
 </div>
 
+## Contributing
 
-### Inspirations for tips: 
+Click on a theme and add your post-it. It doesn’t need to be polished or perfect, even a short tip or small insight could really help someone else.
 
-* “What’s one thing you wish you knew earlier?”
-* “What’s a small thing that made a big difference?”
-* “What advice would you give someone new to this?”
-* “What mistake helped you learn something useful?”
+!!! question "Have something else to share?"
+    Submit your contribution below and the CAKE team will help to place it, or even create a new theme! 
 
+### Inspiration 
 
-## Contributing 
-Got a tip, thought, or bit of advice to add? Click the little page icon at the top of the page to edit it. You’ll be taken to GitHub, where you can add your thoughts and send them over for review in just a few clicks. It doesn’t need to be polished or perfect, even a short tip or small insight could really help someone else.
+* What’s one thing you wish you knew earlier?
+* What’s a small thing that made a big difference?
+* What advice would you give someone new to this?
+* What mistake helped you learn something useful?
 
-Read our [How to contribute](../how-to-contribute/index.md) guide for more.
+### Code of Conduct
 
-Please also familiarise yourself with our [Code of Conduct](../code-of-conduct.md). 
+Please read our [Code of Conduct](../code-of-conduct.md). 
 
+We ask contributors to:
 * Use welcoming and inclusive language
 * Be respectful of different viewpoints and experiences
 * Gracefully accept constructive criticism
 * Focus on what is best for the community
 * Show courtesy and respect towards others
 
+<div class="sticky-board">
+
+{% for tip in tips("template") %}
+
+<div class="sticky-note {{ tip.color }}">
+  <div class="note-title">
+    {{ tip.emoji }} {{ tip.title }}
+  </div>
+
+  <div class="note-text">
+    {{ tip.text }}
+  </div>
+</div>
+
+{% endfor %}
+
+</div>
+
+### Add your sticky note
+
+<div class="submit-box">
+
+  <p class="submit-description">
+    Share a tip, lesson learned, or useful advice with the community.
+  </p>
+  
+  <p class="submit-helper">
+  </br>
+  After clicking <strong>Submit</strong>, a GitHub issue will open
+  with your tip pre-filled. Simply click <strong>Create issue</strong>
+  to send it to the CAKE team for review before it goes live.
+</p>
+
+  <input
+    class="tip-input"
+    id="tip-title"
+    placeholder="Title"
+  />
+
+  <textarea
+    class="tip-textarea"
+    id="tip-text"
+    placeholder="Your text..."
+  ></textarea>
+
+  <div class="tip-controls">
+
+
+<div class="emoji-picker">
+  <p class="emoji-label">
+    Select an emoji:
+  </p>
+
+  <div class="emoji-grid" id="tip-emoji">
+
+    <button type="button" class="emoji-btn active">🤝</button>
+    <button type="button" class="emoji-btn">💡</button>
+    <button type="button" class="emoji-btn">📝</button>
+    <button type="button" class="emoji-btn">🚀</button>
+    <button type="button" class="emoji-btn">🎯</button>
+    <button type="button" class="emoji-btn">🌟</button>
+    <button type="button" class="emoji-btn">📚</button>
+    <button type="button" class="emoji-btn">🧠</button>
+    <button type="button" class="emoji-btn">✨</button>
+    <button type="button" class="emoji-btn">🎨</button>
+    <button type="button" class="emoji-btn">💬</button>
+    <button type="button" class="emoji-btn">🔍</button>
+    <button type="button" class="emoji-btn">📌</button>
+    <button type="button" class="emoji-btn">🛠️</button>
+    <button type="button" class="emoji-btn">🔥</button>
+    <button type="button" class="emoji-btn">📖</button>
+    <button type="button" class="emoji-btn">📱</button>
+    <button type="button" class="emoji-btn">🙌</button>
+  </div>
+</div>
+
+<div class="colour-picker">
+
+  <p class="emoji-label">
+    Select your colour:
+  </p>
+
+  <div class="colour-grid" id="tip-colour">
+
+    <button
+      type="button"
+      class="colour-btn yellow active"
+      data-colour="yellow">
+    </button>
+
+    <button
+      type="button"
+      class="colour-btn blue"
+      data-colour="blue">
+    </button>
+
+    <button
+      type="button"
+      class="colour-btn green"
+      data-colour="green">
+    </button>
+
+    <button
+      type="button"
+      class="colour-btn pink"
+      data-colour="pink">
+    </button>
+
+  </div>
+
+</div>
+
+</div>
+
+<div class="submit-button-row">
+
+  <button
+    class="tip-submit-btn"
+    onclick="submitTip('Inclusion')">
+
+    Submit
+
+  </button>
+
+</div>
+
+
+
+</div>
+
+<script>
+
+document.querySelectorAll(".emoji-btn").forEach(btn => {
+
+  btn.addEventListener("click", () => {
+
+    document
+      .querySelectorAll(".emoji-btn")
+      .forEach(b => b.classList.remove("active"));
+
+    btn.classList.add("active");
+  });
+
+});
+
+</script>
+
+<script>
+
+document.querySelectorAll(".colour-btn").forEach(btn => {
+
+  btn.addEventListener("click", () => {
+
+    document
+      .querySelectorAll(".colour-btn")
+      .forEach(b => b.classList.remove("active"));
+
+    btn.classList.add("active");
+  });
+
+});
+
+</script>
+
+<script>
+function submitTip(theme) {
+
+  const title =
+    document.getElementById("tip-title").value.trim();
+
+  const text =
+    document.getElementById("tip-text").value.trim();
+
+  const emoji =
+    document.querySelector(".emoji-btn.active").textContent;
+
+  const color =
+    document
+    .querySelector(".colour-btn.active")
+    .dataset.colour;
+
+  if (!title || !text) {
+    alert("Please fill in both title and text.");
+    return;
+  }
+
+  const issueTitle =
+    `[Tip:${theme}] ${title}`;
+
+  const issueBody =
+`theme: ${theme}
+title: ${title}
+emoji: ${emoji}
+color: ${color}
+text: ${text}`;
+
+  const url =
+    "https://github.com/CAKE-DRI/CAKEbox/issues/new"
+    + "?labels=tip-submission," + theme
+    + "&title=" + encodeURIComponent(issueTitle)
+    + "&body=" + encodeURIComponent(issueBody);
+
+  window.open(url, "_blank");
+}
+</script>

--- a/docs/community-tips/template-top-tips.md
+++ b/docs/community-tips/template-top-tips.md
@@ -1,6 +1,6 @@
 ---
 title: Top Tips Template
-tags: [Top Tips]
+# tags: [Sprinkles of Knowledge]
 ---
 
 ## About 
@@ -38,8 +38,6 @@ This page is part of our Top Tips campaign — a space to share quick advice, us
 # Template
 
 This page is part of our Top Tips campaign — a space to share quick advice, useful experiences, and things you wish someone had told you earlier.
-
-
 
 <div class="sticky-board">
 

--- a/docs/community-tips/tools.md
+++ b/docs/community-tips/tools.md
@@ -1,15 +1,16 @@
 ---
-title: Facilitation
-tags: [Top Tips, Facilitation]
+title: Tools & Workflows
+tags: [Sprinkles of Knowledge, Tools & Workflows]
 ---
 
-# 🤝 Facilitation
+# 🧠 Tools & Workflows 
+This theme is about **finding the right tools for the right job.** What tools have helped you? What workflows save time or make collaboration easier?
 
-Tips, lessons learned, and community advice about working together effectively.
+Add your sprinkles of knowledge below: a quick tip, small insight, or lesson learned.
 
 <div class="sticky-board">
 
-{% for tip in tips("facilitation") %}
+{% for tip in tips("tools") %}
 
 <div class="sticky-note {{ tip.color }}">
   <div class="note-title">
@@ -27,7 +28,7 @@ Tips, lessons learned, and community advice about working together effectively.
 
 ---
 
-## ✨ Share your experience
+## Add your sticky note
 
 <div class="submit-box">
 
@@ -36,6 +37,7 @@ Tips, lessons learned, and community advice about working together effectively.
   </p>
   
   <p class="submit-helper">
+  </br>
   After clicking <strong>Submit</strong>, a GitHub issue will open
   with your tip pre-filled. Simply click <strong>Create issue</strong>
   to send it to the CAKE team for review before it goes live.
@@ -44,13 +46,13 @@ Tips, lessons learned, and community advice about working together effectively.
   <input
     class="tip-input"
     id="tip-title"
-    placeholder="Tip title"
+    placeholder="Title"
   />
 
   <textarea
     class="tip-textarea"
     id="tip-text"
-    placeholder="Your advice..."
+    placeholder="Your text..."
   ></textarea>
 
   <div class="tip-controls">
@@ -58,7 +60,7 @@ Tips, lessons learned, and community advice about working together effectively.
 
 <div class="emoji-picker">
   <p class="emoji-label">
-    Select an emoji!
+    Select an emoji:
   </p>
 
   <div class="emoji-grid" id="tip-emoji">
@@ -87,7 +89,7 @@ Tips, lessons learned, and community advice about working together effectively.
 <div class="colour-picker">
 
   <p class="emoji-label">
-    Select your sticky note colour!
+    Select your colour:
   </p>
 
   <div class="colour-grid" id="tip-colour">
@@ -126,7 +128,7 @@ Tips, lessons learned, and community advice about working together effectively.
 
   <button
     class="tip-submit-btn"
-    onclick="submitTip('facilitation')">
+    onclick="submitTip('tools')">
 
     Submit
 
@@ -134,6 +136,11 @@ Tips, lessons learned, and community advice about working together effectively.
 
 </div>
 
+---
+
+## Explore our other themes
+
+<!-- material/tags {include: [Sprinkles of Knowledge]} -->
 
 
 </div>

--- a/docs/how-to-contribute/index.md
+++ b/docs/how-to-contribute/index.md
@@ -13,7 +13,7 @@ CAKEbox is hosted on GitHub, making it easy for you to request changes and add r
 
 ### (1) Quick idea or tip
 
-Got a quick thought, tip, or piece of advice? [Add it to our Community Top Tips.](../community-tips/index.md)
+Got a quick thought, tip, or piece of advice? [Add it to our Sprinkles of Knowledge.](../community-tips/index.md)
 
 ### (2) I've found a useful resource
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,37 +10,37 @@ tags:
 <h1 align="center">Welcome to CAKEbox 🍰📦</h1>
 
 <p align="center">
-  A community hub for sharing knowledge, guidance, and practical resources
-  across the UK Digital Research Infrastructure (DRI) landscape.
+  A community knowledge hub for the UK Digital Research Infrastructure (DRI) community
 </p>
 
 ---
 
-## About
+## What is CAKEbox? 
 
-CAKEbox, delivered as part of the [CAKE project](https://www.cake.ac.uk/), is the knowledge-sharing hub for the UK DRI community to:
+CAKEbox is a shared space for practical knowledge from across the UK DRI community.
 
-- Exchange knowledge and experience  
-- Share best practices and lessons learned  
-- Discover reusable templates, guidance, and examples  
-- Signpost useful external resources  
+Here you’ll find:
+
+- Guidance and how-tos  
+- Templates and reusable materials  
+- Real examples from the community  
+- Lessons learned and best practice  
+- Useful external resources  
+
+
 
 ---
 
 
 ## Explore 
 
-CAKEbox is organised around a set of central themes.
-
-Browse the themes below to discover guidance, templates, examples, and community-contributed resources.
+Browse by theme to find resources, tools, and community contributions.
 
 <!-- material/tags {include: [Central themes]} -->
 
 --- 
 
-## Other Useful Hubs
-
-Check-out these great collections from communities within the UK large-scale computing landscape: 
+## Other Hubs
 
 - [Software Sustainability Institute Resources Hub](https://www.software.ac.uk/resource-hub)
     - Including information ranging from software project management and sustainability to event organisation and online training delivery.
@@ -51,11 +51,15 @@ Check-out these great collections from communities within the UK large-scale com
 
 ## Contributing
 
-CAKEbox is built by the community, for the community.
-
-If you have guidance, templates, reflections, examples, or resources that could help others, we would love for you to contribute.
+CAKEbox is built by the community, for the community. Share what you know! 
 
 👉 **[Learn how to contribute](how-to-contribute/index.md)**
+
+Choose how you’d like to contribute:
+
+1. I have a quick idea or tip to share
+2. I've found a useful resource
+3. I want to write something new 
 
 ---
 


### PR DESCRIPTION
Updated the wording on the sticky notes pages, changed facilitation to tools (what do you think?) and made the following undiscoverable: 
* Needs more work: `docs/collaboration-and-community-building/oops-did-we-do-it-right.md` 
* Remove? `docs/community-tips/template-top-tips.md`