### PR TITLE
Adds a community content disclaimer

### DIFF
--- a/docs/community-content-disclaimer.md
+++ b/docs/community-content-disclaimer.md
@@ -1,0 +1,25 @@
+---
+title: Community Content Disclaimer
+---
+
+CAKEbox is a community-driven knowledge hub. Our community has a great wealth of experience, knowledge and recommendation, and this platform is intended to be a space to share these with the wider UK DRI community. 
+
+Content on this site, including articles, guides, recommendations, templates, and opinions, is created, submitted, or edited by community members and is provided for general informational purposes only. It should not be interpreted as professional advice (always seek guidance from professionals where appropriate) and does not necessarily reflect the views of the CAKE team or the wider UK DRI community. 
+
+Whilst we encourage contributors to share accurate and helpful information, we cannot guarantee the completeness, reliability, or correctness of any content. Information may be outdated, incomplete, or incorrect. So, make sure you independently verify any critical information before relying on it.
+
+### EDI Considerations
+
+Much of CAKEbox content is driven by lived experience, including recommendations for resources people have found valuable and opinions on what has worked in specific contexts.
+
+It is important to recognise that these contributions are highly context-specific.
+
+As such, they may not be inclusive, representative, or appropriate for all users or situations. We encourage users to apply critical judgment and consider their own context, needs, and constraints when evaluating recommendations. 
+
+### External Links and Third-Party Content
+
+This platform may contain links or references to third-party resources. We are not responsible for the content, availability, or accuracy of external sites or services.
+
+### Use at Your Own Discretion
+
+By using this platform, you acknowledge that you do so at your own risk. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,3 +73,11 @@ By using this site, you are agreeing to abide by the **[CAKE Code of Conduct](co
 <script>
   sessionStorage.setItem("cameFromHome", "1");
 </script>
+
+---
+
+## Community Content Disclaimer
+
+CAKEbox is a community-driven knowledge hub. Our community has a great wealth of experience, knowledge and recommendation, and this platform is intended to be a space to share these with the wider UK DRI community. 
+
+Read more about our guidance on how to use this platform **[here](community-content-disclaimer.md)**.


### PR DESCRIPTION
Following discussions at the EDI working group around the risk of recommending any and all resources, I've drafted a disclaimer for CAKEbox. This is an idea of how we can preserve the community-driven nature of this site, whilst making sure users understand where the content has come from?